### PR TITLE
Add Dependabot to repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" 
+    directory: "/" 
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This adds Dependabot checks for `basic-test-results`.

This is required per the "Make Repo Public" [checklist](https://www.notion.so/sentry/Moving-Github-Repo-to-Public-Checklist-45a4bf15ad694afaa058048e791eda36?pvs=4).